### PR TITLE
hw/arm/xlnx-versal-virt: modify gem/phy DT nodes

### DIFF
--- a/include/hw/arm/xlnx-versal.h
+++ b/include/hw/arm/xlnx-versal.h
@@ -189,8 +189,10 @@ struct Versal {
 
 #define MM_GEM0                     0xff0c0000U
 #define MM_GEM0_SIZE                0x10000
+#define MM_GEM0_PHY_ID              0xc
 #define MM_GEM1                     0xff0d0000U
 #define MM_GEM1_SIZE                0x10000
+#define MM_GEM1_PHY_ID              0xd
 
 #define MM_ADMA_CH0                 0xffa80000U
 #define MM_ADMA_CH0_SIZE            0x10000


### PR DESCRIPTION
Modify the gem/phy device tree nodes so that VxWorks properly binds the genericPhy driver to the ethernet-phy DT node. Previously, the phy was represented using a fixed-link node that VxWorks does not parse properly.

The compatible string for the gem node has been modified from "cdns,zynqmp-gem" to "cdns,versal-gem". The VxWorks gem driver does not match "cdns,zynqmp-gem".

Note: VxWorks needs additional property "phy-mode" to properly bind the driver against "cdns,versal-gem".