### PR TITLE
[xlnx-versal-virt]: change DT compat string to match vxworks

### DIFF
--- a/hw/arm/xlnx-versal-virt.c
+++ b/hw/arm/xlnx-versal-virt.c
@@ -9,6 +9,8 @@
  * (at your option) any later version.
  *
  * 12 Jan 2024 - Do not return size of dtb from arm_boot_info::get_dtb()
+ * 17 Sep 2024 - Change fixed-link ethernet phy DT node to genericPhy
+ * 25 Sep 2024 - Modify DT compat string from xlnx-versal-virt to xlnx,versal
  *
  */
 
@@ -85,7 +87,7 @@ static void fdt_create(VersalVirt *s)
     qemu_fdt_setprop_cell(s->fdt, "/", "#size-cells", 0x2);
     qemu_fdt_setprop_cell(s->fdt, "/", "#address-cells", 0x2);
     qemu_fdt_setprop_string(s->fdt, "/", "model", mc->desc);
-    qemu_fdt_setprop_string(s->fdt, "/", "compatible", "xlnx-versal-virt");
+    qemu_fdt_setprop_string(s->fdt, "/", "compatible", "xlnx,versal");
 }
 
 static void fdt_add_clk_node(VersalVirt *s, const char *name,


### PR DESCRIPTION
VxWorks looks for "xlnx,versal" compatible string at the top level node of the device tree to match the compatible string in the versal board description found in the VxWorks Versal BSP. VxWorks does not match the "xlnx-versal-virt" compatible string in the qemu generated device tree for this machine model.

Change the compatible string in the device tree that qemu generates for the xlnx-versal-virt board to match VxWorks BOARD_DESC for xilinx versal.