### PR TITLE
match memory ranges to vck190 memory layout

### DIFF
--- a/hw/arm/xlnx-versal-virt.c
+++ b/hw/arm/xlnx-versal-virt.c
@@ -487,8 +487,7 @@ static void fdt_add_memory_nodes(VersalVirt *s, void *fdt, uint64_t ram_size)
     } addr_ranges[] = {
         { MM_TOP_DDR, MM_TOP_DDR_SIZE },
         { MM_TOP_DDR_2, MM_TOP_DDR_2_SIZE },
-        { MM_TOP_DDR_3, MM_TOP_DDR_3_SIZE },
-        { MM_TOP_DDR_4, MM_TOP_DDR_4_SIZE }
+        { MM_TOP_DDR_3, MM_TOP_DDR_3_SIZE }
     };
     uint64_t mem_reg_prop[8] = {0};
     uint64_t size = ram_size;

--- a/hw/arm/xlnx-versal.c
+++ b/hw/arm/xlnx-versal.c
@@ -803,8 +803,7 @@ static void versal_map_ddr(Versal *s)
     } addr_ranges[] = {
         { MM_TOP_DDR, MM_TOP_DDR_SIZE },
         { MM_TOP_DDR_2, MM_TOP_DDR_2_SIZE },
-        { MM_TOP_DDR_3, MM_TOP_DDR_3_SIZE },
-        { MM_TOP_DDR_4, MM_TOP_DDR_4_SIZE }
+        { MM_TOP_DDR_3, MM_TOP_DDR_3_SIZE }
     };
     uint64_t offset = 0;
     int i;

--- a/include/hw/arm/xlnx-versal.h
+++ b/include/hw/arm/xlnx-versal.h
@@ -220,7 +220,7 @@ struct Versal {
 #define MM_TOP_DDR_4_SIZE           0xb780000000ULL
 
 #define MM_PSM_START                0xffc80000U
-#define MM_PSM_END                  0xffcf0000U
+#define MM_PSM_END                  0xffd00000U
 
 #define MM_CRL                      0xff5e0000U
 #define MM_CRL_SIZE                 0x300000

--- a/include/hw/arm/xlnx-versal.h
+++ b/include/hw/arm/xlnx-versal.h
@@ -69,7 +69,7 @@ struct Versal {
 
     struct {
         /* 4 ranges to access DDR.  */
-        MemoryRegion mr_ddr_ranges[4];
+        MemoryRegion mr_ddr_ranges[3];
     } noc;
 
     struct {
@@ -213,11 +213,9 @@ struct Versal {
 #define MM_TOP_DDR                  0x0
 #define MM_TOP_DDR_SIZE             0x80000000U
 #define MM_TOP_DDR_2                0x800000000ULL
-#define MM_TOP_DDR_2_SIZE           0x800000000ULL
-#define MM_TOP_DDR_3                0xc000000000ULL
-#define MM_TOP_DDR_3_SIZE           0x4000000000ULL
-#define MM_TOP_DDR_4                0x10000000000ULL
-#define MM_TOP_DDR_4_SIZE           0xb780000000ULL
+#define MM_TOP_DDR_2_SIZE           0x180000000ULL
+#define MM_TOP_DDR_3                0x50000000000ULL
+#define MM_TOP_DDR_3_SIZE           0x200000000ULL
 
 #define MM_PSM_START                0xffc80000U
 #define MM_PSM_END                  0xffd00000U


### PR DESCRIPTION
bug fix for PSM memory map layout

modify the defined ddr ranges to match the layout on the vck190 dev board.