### PR TITLE
Nho/smmu gem integration

### DIFF
--- a/hw/arm/smmu500.c
+++ b/hw/arm/smmu500.c
@@ -1660,7 +1660,7 @@ static IOMMUTLBEntry smmu_translate(IOMMUMemoryRegion *mr, hwaddr addr,
     TBU *tbu = container_of(mr, TBU, iommu);
     SMMU500State *s = tbu->smmu;
     IOMMUTLBEntry ret = {
-        .target_as = tbu->as,
+        .target_as = &address_space_memory,
         .translated_addr = addr,
         .addr_mask = (1ULL << 12) - 1,
         .perm = IOMMU_RW,
@@ -2216,13 +2216,11 @@ static void smmu500_init(Object *obj)
         char *name = g_strdup_printf("smmu-tbu%d", i);
 
         s->tbu[i].as = g_new0(AddressSpace, 1);
+        /* s->tbu[i].as is initialized by the device connected to s->tbu[i] */
         memory_region_init_iommu(&s->tbu[i].iommu, sizeof(s->tbu[i].iommu),
                                  TYPE_XILINX_SMMU500_IOMMU_MEMORY_REGION,
                                  OBJECT(sbd),
                                  name, UINT64_MAX);
-        address_space_init(s->tbu[i].as,
-                           MEMORY_REGION(&s->tbu[i].iommu),
-                           name);
         g_free(name);
         s->tbu[i].smmu = s;
     }

--- a/hw/arm/smmu500.c
+++ b/hw/arm/smmu500.c
@@ -2230,19 +2230,19 @@ static void smmu500_init(Object *obj)
                              qdev_prop_allow_set_link_before_realize,
                              OBJ_PROP_LINK_STRONG);
 
-    /* The mr-%d property should be set by the implementation of the machine
-     * into which the SMMU is being integrated. The index of the mr corresponds
-     * to the TBU index. Devices connected to a given TBU will have their DMA
-     * addresses translated into the target MemoryRegion as defined by this property.
+    /* The SMMU_TBU_MR_PROP_NAME property should be set by the implementation
+     * of the machine into which the SMMU is being integrated. The index of the
+     * mr corresponds to the TBU index. Devices connected to a given TBU will
+     * have their DMA addresses translated into the target MemoryRegion as
+     * defined by this property.
      */
     for (i = 0; i < MAX_TBU; i++) {
-        char *name = g_strdup_printf("mr-%d", i);
+        char *name = g_strdup_printf(SMMU_TBU_MR_PROP_NAME, i);
         object_property_add_link(obj, name, TYPE_MEMORY_REGION,
                                  (Object **)&s->tbu[i].target_mr,
                                  qdev_prop_allow_set_link_before_realize,
                                  OBJ_PROP_LINK_STRONG);
     }
-
 }
 
 static void smmu_free_rai(SMMU500State *s, RegisterAccessInfo *rai, int num)

--- a/hw/arm/xlnx-versal.c
+++ b/hw/arm/xlnx-versal.c
@@ -828,8 +828,7 @@ static void versal_create_smmu(Versal *s, qemu_irq *pic)
     object_initialize_child(OBJECT(s), "mmu-500", &s->fpd.smmu,
                             TYPE_XILINX_SMMU500);
     sbd = SYS_BUS_DEVICE(&s->fpd.smmu);
-    object_property_set_link(OBJECT(sbd), "dma", OBJECT(&s->mr_ps),
-                             &error_abort);
+    object_property_set_link(OBJECT(sbd), "mr-0", OBJECT(&s->mr_ps), &error_abort);
     sysbus_realize(sbd, &error_fatal);
 
     mr = sysbus_mmio_get_region(sbd, 0);

--- a/hw/arm/xlnx-versal.c
+++ b/hw/arm/xlnx-versal.c
@@ -191,6 +191,16 @@ static void versal_create_uarts(Versal *s, qemu_irq *pic)
     }
 }
 
+static void versal_connect_dev_iommu(Versal *s,
+                                     DeviceState *dev,
+                                     const char *propname,
+                                     int tbuId)
+{
+    object_property_set_link(OBJECT(dev), propname,
+                             OBJECT(&s->fpd.smmu.tbu[tbuId].iommu),
+                             &error_abort);
+}
+
 static void versal_create_canfds(Versal *s, qemu_irq *pic)
 {
     int i;
@@ -255,6 +265,7 @@ static void versal_create_gems(Versal *s, qemu_irq *pic)
     for (i = 0; i < ARRAY_SIZE(s->lpd.iou.gem); i++) {
         static const int irqs[] = { VERSAL_GEM0_IRQ_0, VERSAL_GEM1_IRQ_0};
         static const uint64_t addrs[] = { MM_GEM0, MM_GEM1 };
+        static const int tbu_ids[] = {VERSAL_GEM0_TBUID, VERSAL_GEM1_TBUID };
         char *name = g_strdup_printf("gem%d", i);
         DeviceState *dev;
         MemoryRegion *mr;
@@ -266,8 +277,7 @@ static void versal_create_gems(Versal *s, qemu_irq *pic)
         object_property_set_int(OBJECT(dev), "phy-addr", 23, &error_abort);
         object_property_set_int(OBJECT(dev), "num-priority-queues", 2,
                                 &error_abort);
-        object_property_set_link(OBJECT(dev), "dma", OBJECT(&s->fpd.smmu.tbu[0].iommu),
-                                 &error_abort);
+        versal_connect_dev_iommu(s, dev, "dma", tbu_ids[i]);
         sysbus_realize(SYS_BUS_DEVICE(dev), &error_fatal);
 
         mr = sysbus_mmio_get_region(SYS_BUS_DEVICE(dev), 0);
@@ -824,11 +834,17 @@ static void versal_create_smmu(Versal *s, qemu_irq *pic)
 {
     SysBusDevice *sbd;
     MemoryRegion *mr;
+    int i;
 
     object_initialize_child(OBJECT(s), "mmu-500", &s->fpd.smmu,
                             TYPE_XILINX_SMMU500);
     sbd = SYS_BUS_DEVICE(&s->fpd.smmu);
-    object_property_set_link(OBJECT(sbd), "mr-0", OBJECT(&s->mr_ps), &error_abort);
+
+    for (i = 0; i < VERSAL_SMMU_TBUID_MAX; i++) {
+        char *name = g_strdup_printf(SMMU_TBU_MR_PROP_NAME, i);
+        object_property_set_link(OBJECT(sbd), name,
+                                 OBJECT(&s->mr_ps), &error_abort);
+    }
     sysbus_realize(sbd, &error_fatal);
 
     mr = sysbus_mmio_get_region(sbd, 0);

--- a/hw/arm/xlnx-versal.c
+++ b/hw/arm/xlnx-versal.c
@@ -266,6 +266,7 @@ static void versal_create_gems(Versal *s, qemu_irq *pic)
         static const int irqs[] = { VERSAL_GEM0_IRQ_0, VERSAL_GEM1_IRQ_0};
         static const uint64_t addrs[] = { MM_GEM0, MM_GEM1 };
         static const int tbu_ids[] = {VERSAL_GEM0_TBUID, VERSAL_GEM1_TBUID };
+        static const int stream_ids[] = { VERSAL_GEM0_STREAM_ID, VERSAL_GEM1_STREAM_ID };
         char *name = g_strdup_printf("gem%d", i);
         DeviceState *dev;
         MemoryRegion *mr;
@@ -277,6 +278,7 @@ static void versal_create_gems(Versal *s, qemu_irq *pic)
         object_property_set_int(OBJECT(dev), "phy-addr", 23, &error_abort);
         object_property_set_int(OBJECT(dev), "num-priority-queues", 2,
                                 &error_abort);
+        object_property_set_int(OBJECT(dev), "stream-id", stream_ids[i], &error_abort);
         versal_connect_dev_iommu(s, dev, "dma", tbu_ids[i]);
         sysbus_realize(SYS_BUS_DEVICE(dev), &error_fatal);
 

--- a/hw/arm/xlnx-versal.c
+++ b/hw/arm/xlnx-versal.c
@@ -266,7 +266,7 @@ static void versal_create_gems(Versal *s, qemu_irq *pic)
         object_property_set_int(OBJECT(dev), "phy-addr", 23, &error_abort);
         object_property_set_int(OBJECT(dev), "num-priority-queues", 2,
                                 &error_abort);
-        object_property_set_link(OBJECT(dev), "dma", OBJECT(&s->mr_ps),
+        object_property_set_link(OBJECT(dev), "dma", OBJECT(&s->fpd.smmu.tbu[0].iommu),
                                  &error_abort);
         sysbus_realize(SYS_BUS_DEVICE(dev), &error_fatal);
 
@@ -828,6 +828,8 @@ static void versal_create_smmu(Versal *s, qemu_irq *pic)
     object_initialize_child(OBJECT(s), "mmu-500", &s->fpd.smmu,
                             TYPE_XILINX_SMMU500);
     sbd = SYS_BUS_DEVICE(&s->fpd.smmu);
+    object_property_set_link(OBJECT(sbd), "dma", OBJECT(&s->mr_ps),
+                             &error_abort);
     sysbus_realize(sbd, &error_fatal);
 
     mr = sysbus_mmio_get_region(sbd, 0);

--- a/include/hw/arm/smmu500.h
+++ b/include/hw/arm/smmu500.h
@@ -57,6 +57,9 @@ OBJECT_DECLARE_SIMPLE_TYPE(SMMU500State, XILINX_SMMU500)
 
 #define SMMU_R_MAX (2 * MAX_CB * SMMU_PAGESIZE)
 
+/* Per-TBU Memory Region property name */
+#define SMMU_TBU_MR_PROP_NAME   "mr-%d"
+
 /* Forward declaration */
 struct SMMU500State;
 

--- a/include/hw/arm/smmu500.h
+++ b/include/hw/arm/smmu500.h
@@ -63,7 +63,8 @@ struct SMMU500State;
 typedef struct TBU {
     SMMU500State *smmu;
     IOMMUMemoryRegion iommu;
-    AddressSpace *as;
+    AddressSpace *target_as;
+    MemoryRegion *target_mr;
 } TBU;
 
 typedef struct SMMU500State {

--- a/include/hw/arm/xlnx-versal.h
+++ b/include/hw/arm/xlnx-versal.h
@@ -371,4 +371,8 @@ struct Versal {
 
 G_STATIC_ASSERT(VERSAL_SMMU_TBUID_MAX <= MAX_TBU);
 
+/* SMMU Stream ID */
+#define VERSAL_GEM0_STREAM_ID       0x234
+#define VERSAL_GEM1_STREAM_ID       0x235
+
 #endif

--- a/include/hw/arm/xlnx-versal.h
+++ b/include/hw/arm/xlnx-versal.h
@@ -357,4 +357,18 @@ struct Versal {
 #define MM_PMC_TRNG_SIZE            0x10000
 
 #define MM_PMC_INT_CSR              0xf1330000
+
+/* MMU-500 TBU device mapping
+ *
+ * It is system dependent which devices are connected to which TBU.
+ * The target DMA address space of each TBU is configured independently
+ * (see SMMU property SMMU_TBU_MR_PROP_NAME). Devices connected to the
+ * same TBU will have the same target translation address space.
+ */
+#define VERSAL_GEM0_TBUID       0x0
+#define VERSAL_GEM1_TBUID       0x0
+#define VERSAL_SMMU_TBUID_MAX   VERSAL_GEM1_TBUID + 1
+
+G_STATIC_ASSERT(VERSAL_SMMU_TBUID_MAX <= MAX_TBU);
+
 #endif

--- a/include/hw/net/cadence_gem.h
+++ b/include/hw/net/cadence_gem.h
@@ -62,6 +62,7 @@ struct CadenceGEMState {
     uint8_t num_type2_screeners;
     uint32_t revision;
     uint16_t jumbo_max_len;
+    uint16_t stream_id;
 
     /* GEM registers backing store */
     uint32_t regs[CADENCE_GEM_MAXREG];


### PR DESCRIPTION
Connect the Cadence GEM devices to SMMU-500. HVP guests that attempt to utilize DMA capable devices configured the dma descriptor source/destination address with the guest physical address . In order for this to work properly, the SMMU must do the second level translation from guest physical address to host physical address. This changeset adds the necessary changes to enable GEM DMA to work properly.

This change also adds additional stream-id property to the GEM device implementation so that different DMA devices can be properly matched to the correct context banks within the IOMMU.