### PR TITLE
Restore nxp-s32g machine in QEMU v11

### DIFF
--- a/hw/arm/nxp-s32g.c
+++ b/hw/arm/nxp-s32g.c
@@ -29,6 +29,7 @@
 #include "hw/core/boards.h"
 #include "hw/core/qdev-properties.h"
 #include "hw/arm/nxp-s32g.h"
+#include "hw/arm/machines-qom.h"
 #include "hw/arm/fdt.h"
 #include "hw/misc/unimp.h"
 #include "system/address-spaces.h"
@@ -573,6 +574,7 @@ static const TypeInfo nxp_s32g_machine_info = {
     .instance_size = sizeof(NxpS32gState),
     .class_init = nxp_s32g_machine_class_init,
     .instance_init = nxp_s32g_machine_instance_init,
+    .interfaces = aarch64_machine_interfaces,
 };
 
 static void nxp_s32g_machine_init(void)


### PR DESCRIPTION
Updated the nxp-s32g code to include changes made in QEMU v11 so the machine is accessible again.

<img width="739" height="72" alt="image" src="https://github.com/user-attachments/assets/8f4a1ca2-bfa6-4409-a349-9b68ca106c47" />

It looks like you need to include `hw/arm/machines-qom.h` and then either set `.interfaces = aarch64_machine_interfaces` in `TypeInfo` or run `DEFINE_MACHINE_AARCH64`.
 
`DEFINE_MACHINE_AARCH64` goes through a few layers before arriving at `DEFINE_MACHINE_EXTENDED` which sets `.interfaces = ifaces`, so it seems like they do the same things and you don't need to use both. `xlnx-zcu102.c` only uses `.interfaces = aarch64_machine_interfaces` while `imx8mp-evk.c` only uses `DEFINE_MACHINE_AARCH64`.

<img width="644" height="186" alt="image" src="https://github.com/user-attachments/assets/da902106-57b4-4279-a7e8-bc1773b08d72" />
