### PR TITLE
Pack final DTB unconditionally

### DIFF
--- a/hw/arm/boot.c
+++ b/hw/arm/boot.c
@@ -640,12 +640,10 @@ int arm_load_dtb(hwaddr addr, const struct arm_boot_info *binfo,
      * By default QEMU generates a 1 MiB FDT.
      * Let's pack it to save some room.
      */
-    if (binfo->get_dtb) {
-        rc = fdt_pack(fdt);
-        /* Should only fail if we've built a corrupted tree */
-        g_assert(rc == 0);
-        size = fdt_totalsize(fdt);
-    }
+    rc = fdt_pack(fdt);
+    /* Should only fail if we've built a corrupted tree */
+    g_assert(rc == 0);
+    size = fdt_totalsize(fdt);
 
     /* Put the DTB into the memory map as a ROM image: this will ensure
      * the DTB is copied again upon reset, even if addr points into RAM.

--- a/hw/arm/nxp-s32g.c
+++ b/hw/arm/nxp-s32g.c
@@ -29,6 +29,7 @@
 #include "hw/core/boards.h"
 #include "hw/core/qdev-properties.h"
 #include "hw/arm/nxp-s32g.h"
+#include "hw/arm/machines-qom.h"
 #include "hw/arm/fdt.h"
 #include "hw/misc/unimp.h"
 #include "system/address-spaces.h"
@@ -573,6 +574,7 @@ static const TypeInfo nxp_s32g_machine_info = {
     .instance_size = sizeof(NxpS32gState),
     .class_init = nxp_s32g_machine_class_init,
     .instance_init = nxp_s32g_machine_instance_init,
+    .interfaces = aarch64_machine_interfaces,
 };
 
 static void nxp_s32g_machine_init(void)


### PR DESCRIPTION
QEMU currently packs the DTB only when binfo->get_dtb is set, which covers QEMU-generated DTBs but can miss DTBs passed with -dtb. This changes allows all DTB's to be packed, by simply removing the if statement guard.