### PR TITLE
Pack final DTB unconditionally

### DIFF
--- a/hw/arm/boot.c
+++ b/hw/arm/boot.c
@@ -640,12 +640,11 @@ int arm_load_dtb(hwaddr addr, const struct arm_boot_info *binfo,
      * By default QEMU generates a 1 MiB FDT.
      * Let's pack it to save some room.
      */
-    if (binfo->get_dtb) {
-        rc = fdt_pack(fdt);
-        /* Should only fail if we've built a corrupted tree */
-        g_assert(rc == 0);
-        size = fdt_totalsize(fdt);
-    }
+    rc = fdt_pack(fdt);
+    /* Should only fail if we've built a corrupted tree */
+    g_assert(rc == 0);
+    size = fdt_totalsize(fdt);
+
 
     /* Put the DTB into the memory map as a ROM image: this will ensure
      * the DTB is copied again upon reset, even if addr points into RAM.


### PR DESCRIPTION
QEMU currently packs the DTB only when binfo->get_dtb is set, which covers QEMU-generated DTBs but can miss DTBs passed with -dtb. This changes allows all DTB's to be packed, by simply removing the if statement guard.