### PR TITLE
Update nxp-s32g doc for VxWorks 26.03

### DIFF
--- a/docs/wind/vxworks_nxp-s32g.rst
+++ b/docs/wind/vxworks_nxp-s32g.rst
@@ -1,5 +1,5 @@
 =========================================
-VxWorks 24.03 on nxp-s32g machine
+VxWorks 26.03 on nxp-s32g machine
 =========================================
 
 This document contains steps to build a basic VxWorks project for the QEMU nxp-s32g machine.
@@ -27,6 +27,12 @@ support for this, add the following config to your VSB:
 .. code::
 
  $ vxprj vsb add CAN
+
+Enable `_WRS_CONFIG_SERVICE_VIRTIO` so the components `INCLUDE_NET_VIRTIO`, `DRV_FDT_VIRTIO`, and `INCLUDE_VIRTIO_LIB` can be added to the VIP:
+
+.. code::
+
+ $ vxprj vsb config -s -add _WRS_CONFIG_SERVICE_VIRTIO=y
 
 Build the VxWorks Source Build project
 


### PR DESCRIPTION
In VxWorks 26.03, the configuration `_WRS_CONFIG_SERVICE_VIRTIO` has to be set to `y`. Otherwise, attempting to add `INCLUDE_NET_VIRTIO`, `DRV_FDT_VIRTIO`, and `INCLUDE_VIRTIO_LIB` results in the following error.

```
$ vxprj component add INCLUDE_NET_VIRTIO DRV_FDT_VIRTIO \
                      INCLUDE_VIRTIO_LIB
component(s) INCLUDE_VIRTIO_LIB INCLUDE_NET_VIRTIO do not exist
The following components were not added, the VSB does not support them:
DRV_FDT_VIRTIO
```