### PR TITLE
hw/arm/xlnx-versal: fix Versal2 VxWorks CPU boot

### DIFF
--- a/hw/arm/xlnx-versal-virt.c
+++ b/hw/arm/xlnx-versal-virt.c
@@ -66,7 +66,7 @@ static void fdt_create(VersalVirt *s)
     MachineClass *mc = MACHINE_GET_CLASS(s);
     VersalVirtClass *vvc = XLNX_VERSAL_VIRT_BASE_MACHINE_GET_CLASS(s);
     const char versal_compat[] = "xlnx,versal\0amd,versal\0amd-versal-virt\0xlnx-versal-virt";
-    const char versal2_compat[] = "amd-versal2-virt";
+    const char versal2_compat[] = "amd,versal2\0amd-versal2-virt";
 
     s->fdt = create_device_tree(&s->fdt_size);
     if (!s->fdt) {

--- a/hw/arm/xlnx-versal.c
+++ b/hw/arm/xlnx-versal.c
@@ -1122,14 +1122,13 @@ static void versal_create_cpu_dtb(Versal *s, const VersalCpuClusterMap *map,
                                   size_t core_idx)
 {
     ARMCPU *arm_cpu = ARM_CPU(cpu);
-    size_t idx = cluster_idx * map->num_core + core_idx;
+    uint64_t affinity = arm_cpu_mp_affinity(arm_cpu) & ARM64_AFFINITY_MASK;
     g_autofree char *node = NULL;
 
-    node = versal_fdt_add_subnode(s, "/cpus/cpu", idx,
+    node = versal_fdt_add_subnode(s, "/cpus/cpu", affinity,
                                   arm_cpu->dtb_compatible,
                                   strlen(arm_cpu->dtb_compatible) + 1);
-    qemu_fdt_setprop_cell(s->cfg.fdt, node, "reg",
-                          arm_cpu_mp_affinity(arm_cpu) & ARM64_AFFINITY_MASK);
+    qemu_fdt_setprop_cell(s->cfg.fdt, node, "reg", affinity);
     qemu_fdt_setprop_string(s->cfg.fdt, node, "device_type", "cpu");
     qemu_fdt_setprop_string(s->cfg.fdt, node, "enable-method", "psci");
 }


### PR DESCRIPTION
VxWorks requires the QEMU generated Versal2 DTB to expose the expected board compatible string and CPU node number to boot Vxworks and turn on the secondary CPUs. This change adds the amd,versal2 compatible string for amd-versal2-virt and updates CPU DT node generation to use the MPIDR affinity value for the CPU node unit address.
Previously, QEMU generated CPU node names from a linear CPU index while setting reg to the MPIDR affinity value, producing nodes such as cpu@1 with reg = <0x100>. VxWorks looks up secondary CPU nodes using the MPIDR-based CPU ID, for example /cpus/cpu@100. Since cpu@100 did not exist, vxFdtPathOffset() failed and the CPU enable path returned before reaching vxPsciCpuOn() / PSCI CPU_ON. Using the MPIDR affinity value for both the unit address and reg produces nodes such as cpu@100 with reg = <0x100>. With this change, VxWorks discovers the secondary CPU nodes correctly and brings all 8 application CPUs online on amd-versal2-virt. Tested by booting VxWorks 26.03 SMP on amd-versal2-virt and confirming vxCpuEnabledGet() returns 0xff.