### PR TITLE
docs/wind: document S32G missing symbol table fix

### DIFF
--- a/docs/wind/vxworks_nxp-s32g.rst
+++ b/docs/wind/vxworks_nxp-s32g.rst
@@ -131,3 +131,21 @@ To boot and run VxWorks with FlexCAN controller connected to the virtual CAN int
      -object can-bus,id=canbus0-bus \
      -machine canbus0=canbus0-bus \
      -object can-host-socketcan,id=socketcan0,if=vcan0,canbus=canbus0-bus
+
+Troubleshooting
+===============
+
+Network Symbol Table Error
+---------------------------
+
+If you happen to see a network symbol table error:
+
+.. code::
+
+ Error opening /host.host/vxWorks.sym: status = 0x290010
+
+Add the standalone symbol table component to your project, which removes the dependency on the network symbol table:
+
+.. code::
+
+ $ vxprj component add INCLUDE_STANDALONE_SYM_TBL


### PR DESCRIPTION
In the NXP-S32G guide, the VxWorks image created by it attempts to use a network symbol table. If the symbol table is not found, it leads to an error on startup and the C interpreter does not work because there are no symbols.

This pull request adds a troubleshooting section which fixes it by adding INCLUDE_STANDALONE_SYM_TBL, which automatically removes INCLUDE_NET_SYM_TBL.

It is a direct copy of what @shivkd wrote in #44 because it is the same error with the same solution.