### PR TITLE
test: add VxWorks boot test for sabrelite board

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         working-directory: qemu
         run: |
           export PATH="/usr/lib/ccache:$PATH"
-          ./configure --target-list="aarch64-softmmu,x86_64-softmmu" --enable-fdt --enable-plugins --enable-slirp --enable-capstone --disable-vhost-net --disable-vhost-user --enable-gnutls
+          ./configure --target-list="arm-softmmu,aarch64-softmmu,x86_64-softmmu" --enable-fdt --enable-plugins --enable-slirp --enable-capstone --disable-vhost-net --disable-vhost-user --enable-gnutls
           make -j$(nproc)
           make plugins
           make check-build
@@ -124,8 +124,15 @@ jobs:
       - name: Print ccache stats
         run: ccache --show-stats
 
+      - name: Set up VxWorks Sabrelite SDK
+        run: |
+          git clone https://${{ secrets.VXWORKS_IMAGES_TOKEN }}@github.com/hungmtruong/vxworks-images.git \
+            ${{ github.workspace }}/vxworks-images
+
       - name: Run QEMU tests
         working-directory: qemu
+        env:
+          QEMU_TEST_VXWORKS_SABRELITE_SDK: ${{ github.workspace }}/vxworks-images
         run: |
           V=1 make check
 

--- a/tests/functional/arm/meson.build
+++ b/tests/functional/arm/meson.build
@@ -23,12 +23,14 @@ test_arm_timeouts = {
   'quanta_gsj' : 240,
   'raspi2' : 120,
   'replay' : 240,
+  'sabrelite_vxworks' : 120,
   'tuxrun' : 240,
   'sx1' : 360,
 }
 
 tests_arm_system_quick = [
   'migration',
+  'sabrelite_vxworks',
 ]
 
 tests_arm_system_thorough = [

--- a/tests/functional/arm/test_sabrelite_vxworks.py
+++ b/tests/functional/arm/test_sabrelite_vxworks.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+#
+# Functional test that boots VxWorks on the QEMU Sabrelite (i.MX6Q) machine
+# and checks the console for a successful boot.
+#
+# Copyright (c) 2026 Wind River Systems, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import os
+
+from qemu_test import QemuSystemTest, wait_for_console_pattern
+
+VXWORKS_SDK_PATH = os.environ.get(
+    'QEMU_TEST_VXWORKS_SABRELITE_SDK',
+    '/opt/wrsdk/vxworks-images'
+)
+
+BSP_DIR = os.path.join(VXWORKS_SDK_PATH, 'sabrelite')
+
+
+class SabreliteVxWorksTest(QemuSystemTest):
+    """Boot VxWorks on the QEMU sabrelite (i.MX6Q) machine."""
+
+    def test_vxworks_boot(self):
+        """
+        Boot VxWorks on sabrelite and wait for the shell prompt.
+
+        The VxWorks image and DTB are expected to be provided by an SDK
+        installed at a path defined by the QEMU_TEST_VXWORKS_SABRELITE_SDK
+        environment variable (default: /opt/wrsdk/wrsdk-vxworks7-qemu-sabrelite).
+        """
+        kernel = os.path.join(BSP_DIR, 'uVxWorks')
+        dtb = os.path.join(BSP_DIR, 'imx6q-sabrelite.dtb')
+
+        if not os.path.exists(kernel):
+            self.skipTest(f'VxWorks kernel image not found: {kernel}')
+        if not os.path.exists(dtb):
+            self.skipTest(f'VxWorks DTB not found: {dtb}')
+
+        self.set_machine('sabrelite')
+        # The sabrelite board uses the second UART as serial console,
+        # so we set console_index=1 and add -serial null for the first.
+        self.vm.set_console(console_index=1)
+        self.vm.add_args('-smp', '4')
+        self.vm.add_args('-m', '1G')
+        self.vm.add_args('-serial', 'null')
+        self.vm.add_args('-kernel', kernel)
+        self.vm.add_args('-dtb', dtb)
+        self.vm.launch()
+
+        wait_for_console_pattern(self, '->')
+
+
+if __name__ == '__main__':
+    QemuSystemTest.main()


### PR DESCRIPTION
Add a functional test that boots VxWorks on the QEMU sabrelite (i.MX6Q) machine and waits for the shell prompt. The test images are fetched from a private repo (hungmtruong/vxworks-images) during CI.

Changes:
- Add tests/functional/arm/test_sabrelite_vxworks.py
- Register in tests/functional/arm/meson.build (quick + 120s timeout)
- Update CI to build arm-softmmu, clone vxworks-images, and set SDK path