### PR TITLE
test: add boot test for sifive u board

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         working-directory: qemu
         run: |
           export PATH="/usr/lib/ccache:$PATH"
-          ./configure --target-list="arm-softmmu,aarch64-softmmu,x86_64-softmmu" --enable-fdt --enable-plugins --enable-slirp --enable-capstone --disable-vhost-net --disable-vhost-user --enable-gnutls
+          ./configure --target-list="arm-softmmu,aarch64-softmmu,riscv64-softmmu,x86_64-softmmu" --enable-fdt --enable-plugins --enable-slirp --enable-capstone --disable-vhost-net --disable-vhost-user --enable-gnutls
           make -j$(nproc)
           make plugins
           make check-build
@@ -133,6 +133,7 @@ jobs:
         working-directory: qemu
         env:
           QEMU_TEST_VXWORKS_SABRELITE_SDK: ${{ github.workspace }}/vxworks-images
+          QEMU_TEST_VXWORKS_SIFIVE_U_SDK: ${{ github.workspace }}/vxworks-images
         run: |
           V=1 make check
 

--- a/tests/functional/riscv64/meson.build
+++ b/tests/functional/riscv64/meson.build
@@ -8,6 +8,7 @@ test_riscv64_timeouts = {
 tests_riscv64_system_quick = [
   'migration',
   'opensbi',
+  'sifive_u_vxworks',
 ]
 
 tests_riscv64_system_thorough = [

--- a/tests/functional/riscv64/test_sifive_u_vxworks.py
+++ b/tests/functional/riscv64/test_sifive_u_vxworks.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+#
+# Functional test that boots a VxWorks kernel on a SiFive U machine
+# and checks the console for a successful boot.
+#
+# Copyright (c) 2026 Wind River Systems, Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+import os
+
+from qemu_test import QemuSystemTest, wait_for_console_pattern
+
+
+VXWORKS_SDK_PATH = os.environ.get(
+    'QEMU_TEST_VXWORKS_SIFIVE_U_SDK',
+    '/opt/wrsdk/vxworks-images'
+)
+
+BSP_DIR = os.path.join(VXWORKS_SDK_PATH, 'sifive_u')
+
+
+class SiFiveUVxWorksTest(QemuSystemTest):
+    """Boot VxWorks on SiFive U machine."""
+
+    timeout = 30
+
+    def test_vxworks_boot(self):
+        """
+        Boot VxWorks on SiFive U and wait for the shell prompt.
+
+        The VxWorks image is expected at a path defined by the
+        QEMU_TEST_VXWORKS_SIFIVE_U_SDK environment variable
+        (default: /opt/wrsdk/vxworks-images).
+
+        Expected layout:
+          <SDK_PATH>/sifive_u/uVxWorks
+        """
+
+        kernel = os.path.join(BSP_DIR, 'uVxWorks')
+
+        if not os.path.exists(kernel):
+            self.skipTest(f'VxWorks kernel image not found: {kernel}')
+
+        self.set_machine('sifive_u')
+        self.vm.set_console()
+        self.vm.add_args('-smp', '5')
+        self.vm.add_args('-m', '2G')
+        self.vm.add_args('-kernel', kernel)
+        self.vm.launch()
+
+        wait_for_console_pattern(self, '->')
+
+
+if __name__ == '__main__':
+    QemuSystemTest.main()


### PR DESCRIPTION
Add a functional test that boots VxWorks on the QEMU siFive u machine and waits for the shell prompt. The test images are fetched from a private repo (hungmtruong/vxworks-images) during CI.

Changes:

- Add tests/functional/riscv64/test_sifive_u_vxworks.py
- Register in tests/functional/riscv64/meson.build (quick)
- Update CI to build riscv64-softmmu, clone vxworks-images, and set SDK path
