### PR TITLE
Fix(hw): Add phy_id to Versal 2 GEM0 and GEM1

### DIFF
--- a/hw/arm/xlnx-versal.c
+++ b/hw/arm/xlnx-versal.c
@@ -465,8 +465,8 @@ static const VersalMap VERSAL2_MAP = {
     .canfd[3] = { 0xf1a10000, 96 },
     .num_canfd = 4,
 
-    .gem[0] = { { 0xf1a60000, 39 }, 2, "rgmii-id", 1000 },
-    .gem[1] = { { 0xf1a70000, 41 }, 2, "rgmii-id", 1000 },
+    .gem[0] = { { 0xf1a60000, 39 }, 2, "rgmii-id", 1000, 0xc },
+    .gem[1] = { { 0xf1a70000, 41 }, 2, "rgmii-id", 1000, 0xd },
     .gem[2] = { { 0xed920000, 164 }, 4, "usxgmii", 10000 }, /* MMI 10Gb GEM */
     .num_gem = 3,
 


### PR DESCRIPTION
Add phy_id values (0xc and 0xd) to the Versal 2 GEM0 and GEM1 entries, matching the original Versal configuration.

Without phy_id set, the generated device tree uses a **fixed-link** node with _cdns,zynqmp-gem_ compatible string. VxWorks requires a **genericPhy** child node (produced when phy_id is non-zero) with the _cdns,versal-gem_ compatible string to successfully probe and attach the GEM network interfaces.

The 10Gb GEM2 (usxgmii) is intentionally left without phy_id — the VxWorks GEM driver does not recognize usxgmii as a valid phy-mode (**phyConnectTypeGet()** in endMedia.h has no mapping for it), so the interface cannot be used regardless.